### PR TITLE
Add foreign keys

### DIFF
--- a/src/build2myprint/admin.py
+++ b/src/build2myprint/admin.py
@@ -1,2 +1,61 @@
 from django.contrib import admin
 
+
+from .models import ServiceconsumerT, BudgettransactionsT, GroupmembershipT, ConsumeridentitiesT
+
+
+class ServiceconsumerTAdmin(admin.ModelAdmin):
+    readonly_fields = [f.name for f in ServiceconsumerT._meta.fields]
+    list_display = ('id', 'name', 'login', 'defaultgroupid', 'defaultcostcenter')
+    search_fields = ['id', 'name', 'login', 'defaultgroupid', 'defaultcostcenter', 'emailaddress']
+
+    def has_add_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+
+class BudgettransactionsTAdmin(admin.ModelAdmin):
+    readonly_fields = [f.name for f in BudgettransactionsT._meta.fields]
+    list_display = list([f.name for f in BudgettransactionsT._meta.fields])
+    list_display_links = (None)
+    search_fields = ['entity__id', 'entity__name', 'entity__login', 'serviceusage']
+
+    def has_add_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+
+class GroupmembershipTAdmin(admin.ModelAdmin):
+    readonly_fields = [f.name for f in GroupmembershipT._meta.fields]
+    list_display = ('userid', 'groupid')
+    list_display_links = (None)
+    search_fields = ['userid__name', 'userid__id', 'userid__login', 'groupid__value']
+
+    def has_add_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+
+class ConsumeridentitiesTAdmin(admin.ModelAdmin):
+    readonly_fields = [f.name for f in ConsumeridentitiesT._meta.fields]
+    list_display = ('id', 'consumerid', 'value')
+    list_display_links = (None)
+    search_fields = ['id', 'value']
+
+    def has_add_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+
+admin.site.register(ServiceconsumerT, ServiceconsumerTAdmin)
+admin.site.register(BudgettransactionsT, BudgettransactionsTAdmin)
+admin.site.register(GroupmembershipT, GroupmembershipTAdmin)
+admin.site.register(ConsumeridentitiesT, ConsumeridentitiesTAdmin)

--- a/src/build2myprint/models.py
+++ b/src/build2myprint/models.py
@@ -138,17 +138,18 @@ class BudgettransactionsT(models.Model):
     transactiontime = models.DateTimeField(db_column='TransactionTime', primary_key=True)  # Field name made lowercase.
     transactiontype = models.IntegerField(db_column='TransactionType')  # Field name made lowercase.
     amount = models.FloatField(db_column='Amount', blank=True, null=True)  # Field name made lowercase.
-    #entity = models.CharField(db_column='Entity', max_length=36)  # Field name made lowercase.
-    entity = models.ForeignKey('ServiceconsumerT', db_column='Entity', primary_key=True)
-    #service = models.CharField(db_column='Service', max_length=36, blank=True, null=True)  # Field name made lowercase.
-    service = models.ForeignKey('ServiceT', db_column='Service')
-    serviceusage = models.CharField(db_column='ServiceUsage', max_length=36, blank=True, null=True)  # Field name made lowercase.
+    # entity = models.CharField(db_column='Entity', max_length=36)  # Field name made lowercase.
+    entity = models.ForeignKey('ServiceconsumerT', db_column='Entity')
+    # service = models.CharField(db_column='Service', max_length=36, blank=True, null=True)  # Field name made lowercase.
+    service = models.ForeignKey('ServiceT', db_column='Service', primary_key=True)
+    # serviceusage = models.CharField(db_column='ServiceUsage', max_length=36, blank=True, null=True)  # Field name made lowercase.
+    serviceusage = StringUUIDField(db_column='ServiceUsage', blank=True, null=True)
     transactiondata = models.CharField(db_column='TransactionData', max_length=100, blank=True, null=True)  # Field name made lowercase.
 
     class Meta:
         managed = False
         db_table = 'BudgetTransactions_T'
-        unique_together = ('entity', 'transactiontime')
+        unique_together = ('entity', 'transactiontime', 'service')
 
 
 class Camipro(models.Model):
@@ -213,10 +214,14 @@ class ConsumeridentitiesT(models.Model):
     defaultidentity = models.IntegerField(db_column='DefaultIdentity', blank=True, null=True)  # Field name made lowercase.
     visibility = models.IntegerField(db_column='Visibility', blank=True, null=True)  # Field name made lowercase.
     dispositionchecked = models.IntegerField(db_column='DispositionChecked', blank=True, null=True)  # Field name made lowercase.
+    entitylinked = models.ManyToManyField('ServiceconsumerT', through='GroupmembershipT', through_fields=('groupid', 'userid'))
 
     class Meta:
         managed = False
         db_table = 'ConsumerIdentities_T'
+
+    def __str__(self):
+        return self.value
 
 
 class Copernic(models.Model):
@@ -306,7 +311,8 @@ class GroupmembershipT(models.Model):
     # userid = StringUUIDField(db_column='UserID', primary_key=True)
     userid = models.ForeignKey('ServiceconsumerT', db_column='UserID', primary_key=True)
     # groupid = models.CharField(db_column='GroupID', max_length=36, blank=True, null=True)  # Field name made lowercase.
-    groupid = StringUUIDField(db_column='GroupID', blank=True, null=True)
+    # groupid = StringUUIDField(db_column='GroupID', blank=True, null=True)
+    groupid = models.ForeignKey(ConsumeridentitiesT, db_column='GroupID', to_field='consumerid')
 
     class Meta:
         managed = False
@@ -443,7 +449,8 @@ class ServiceconsumerT(models.Model):
     classdata = models.BinaryField(db_column='ClassData', blank=True, null=True)  # Field name made lowercase.
     name = models.CharField(db_column='Name', max_length=50, blank=True, null=True)  # Field name made lowercase.
     login = models.CharField(db_column='Login', max_length=50, blank=True, null=True)  # Field name made lowercase.
-    defaultgroupid = models.CharField(db_column='DefaultGroupID', max_length=36, blank=True, null=True)  # Field name made lowercase.
+    # defaultgroupid = models.CharField(db_column='DefaultGroupID', max_length=36, blank=True, null=True)  # Field name made lowercase.
+    defaultgroupid = StringUUIDField(db_column='DefaultGroupID', blank=True, null=True)  # Field name made lowercase.
     usertypeex = models.IntegerField(db_column='UserTypeEx', blank=True, null=True)  # Field name made lowercase.
     payconid = models.CharField(db_column='PayConID', max_length=50, blank=True, null=True)  # Field name made lowercase.
     usertype = models.CharField(db_column='UserType', max_length=20, blank=True, null=True)  # Field name made lowercase.
@@ -454,7 +461,8 @@ class ServiceconsumerT(models.Model):
     phone = models.CharField(db_column='Phone', max_length=50, blank=True, null=True)  # Field name made lowercase.
     fax = models.CharField(db_column='Fax', max_length=50, blank=True, null=True)  # Field name made lowercase.
     memo = models.CharField(db_column='Memo', max_length=250, blank=True, null=True)  # Field name made lowercase.
-    defaultcostcenter = models.CharField(db_column='DefaultCostCenter', max_length=36, blank=True, null=True)  # Field name made lowercase.
+    # defaultcostcenter = models.CharField(db_column='DefaultCostCenter', max_length=36, blank=True, null=True)  # Field name made lowercase.
+    defaultcostcenter = StringUUIDField(db_column='DefaultCostCenter', blank=True, null=True)
     hasbiodata = models.IntegerField(db_column='HasBioData', blank=True, null=True)  # Field name made lowercase.
     visibility = models.IntegerField(db_column='Visibility', blank=True, null=True)  # Field name made lowercase.
     emergencyaccountflag = models.NullBooleanField(db_column='EmergencyAccountFlag')  # Field name made lowercase.
@@ -462,12 +470,14 @@ class ServiceconsumerT(models.Model):
     sapname = models.CharField(db_column='SAPName', max_length=50, blank=True, null=True)  # Field name made lowercase.
     pincodehash = models.CharField(db_column='PinCodeHash', max_length=80, blank=True, null=True)  # Field name made lowercase.
     momsyncflag = models.NullBooleanField(db_column='MomSyncFlag')  # Field name made lowercase.
-    linkedconsumerid = models.CharField(db_column='LinkedConsumerID', max_length=36, blank=True, null=True)  # Field name made lowercase.
+    # linkedconsumerid = models.CharField(db_column='LinkedConsumerID', max_length=36, blank=True, null=True)  # Field name made lowercase.
+    linkedconsumerid = StringUUIDField(db_column='LinkedConsumerID', blank=True, null=True)
     modified = models.DateTimeField(db_column='Modified', blank=True, null=True)  # Field name made lowercase.
     customprop_igstatus = models.CharField(db_column='CustomProp_IGStatus', max_length=5, blank=True, null=True)  # Field name made lowercase.
     customprop_iglogin = models.CharField(db_column='CustomProp_IGLOGIN', max_length=50, blank=True, null=True)  # Field name made lowercase.
     state = models.CharField(db_column='State', max_length=10, blank=True, null=True)  # Field name made lowercase.
-    hierarchyposition = models.CharField(db_column='HierarchyPosition', max_length=36, blank=True, null=True)  # Field name made lowercase.
+    # hierarchyposition = models.CharField(db_column='HierarchyPosition', max_length=36, blank=True, null=True)  # Field name made lowercase.
+    hierarchyposition = StringUUIDField(db_column='HierarchyPosition', blank=True, null=True)
     forcedrilldown = models.IntegerField(db_column='ForceDrillDown', blank=True, null=True)  # Field name made lowercase.
     emailaddress = models.CharField(db_column='EmailAddress', max_length=50, blank=True, null=True)  # Field name made lowercase.
     objectcontainerversion = models.IntegerField(db_column='OBJECTCONTAINERVERSION', blank=True, null=True)  # Field name made lowercase.
@@ -475,6 +485,9 @@ class ServiceconsumerT(models.Model):
     class Meta:
         managed = False
         db_table = 'ServiceConsumer_T'
+
+    def __str__(self):
+        return '{} : {}/{}'.format(self.id, self.name, self.login)
 
 
 class ServiceproviderT(models.Model):

--- a/src/build2myprint/models.py
+++ b/src/build2myprint/models.py
@@ -22,7 +22,7 @@ class StringUUIDField(models.Field):
 
 
 class AccesscontrollistsT(models.Model):
-    #id = models.CharField(db_column='ID', max_length=36, primary_key=True)  # Field name made lowercase.
+    id = models.CharField(db_column='ID', max_length=36, primary_key=True)  # Field name made lowercase.
     classdata = models.BinaryField(db_column='ClassData', blank=True, null=True)  # Field name made lowercase.
     name = models.CharField(db_column='Name', max_length=50, blank=True, null=True)  # Field name made lowercase.
 

--- a/src/build2myprint/models.py
+++ b/src/build2myprint/models.py
@@ -1,10 +1,28 @@
 from __future__ import unicode_literals
 
+import uuid
+
 from django.db import models
 
 
+class StringUUIDField(models.Field):
+    def from_db_value(self, value, expression, connection, context):
+        if value is None:
+            return value
+        return str(uuid.UUID(bytes_le=value)).upper()
+
+    def to_python(self, value):
+        if isinstance(value, str):
+            return value
+
+        if value is None:
+            return value
+
+        return str(uuid.UUID(bytes_le=value)).upper()
+
+
 class AccesscontrollistsT(models.Model):
-    id = models.CharField(db_column='ID', max_length=36, primary_key=True)  # Field name made lowercase.
+    #id = models.CharField(db_column='ID', max_length=36, primary_key=True)  # Field name made lowercase.
     classdata = models.BinaryField(db_column='ClassData', blank=True, null=True)  # Field name made lowercase.
     name = models.CharField(db_column='Name', max_length=50, blank=True, null=True)  # Field name made lowercase.
 
@@ -120,9 +138,12 @@ class BudgettransactionsT(models.Model):
     transactiontime = models.DateTimeField(db_column='TransactionTime')  # Field name made lowercase.
     transactiontype = models.IntegerField(db_column='TransactionType')  # Field name made lowercase.
     amount = models.FloatField(db_column='Amount', blank=True, null=True)  # Field name made lowercase.
-    entity = models.CharField(db_column='Entity', max_length=36)  # Field name made lowercase.
-    service = models.CharField(db_column='Service', max_length=36, blank=True, null=True)  # Field name made lowercase.
-    serviceusage = models.CharField(db_column='ServiceUsage', max_length=36, blank=True, null=True)  # Field name made lowercase.
+    #entity = models.CharField(db_column='Entity', max_length=36)  # Field name made lowercase.
+    entity = models.ForeignKey('ServiceconsumerT', db_column='Entity')
+    #service = models.CharField(db_column='Service', max_length=36, blank=True, null=True)  # Field name made lowercase.
+    service = models.ForeignKey('ServiceT', db_column='Service')
+    #serviceusage = models.CharField(db_column='ServiceUsage', max_length=36, blank=True, null=True)  # Field name made lowercase.
+    service = models.ForeignKey('ServiceusageT', db_column='ServiceUsage')
     transactiondata = models.CharField(db_column='TransactionData', max_length=100, blank=True, null=True)  # Field name made lowercase.
 
     class Meta:
@@ -411,7 +432,8 @@ class Reportdata(models.Model):
 
 
 class ServiceconsumerT(models.Model):
-    id = models.CharField(db_column='ID', max_length=36, primary_key=True)  # Field name made lowercase.
+    #id = models.CharField(db_column='ID', max_length=36, primary_key=True)  # Field name made lowercase.
+    id = StringUUIDField(db_column='ID', primary_key=True)
     classdata = models.BinaryField(db_column='ClassData', blank=True, null=True)  # Field name made lowercase.
     name = models.CharField(db_column='Name', max_length=50, blank=True, null=True)  # Field name made lowercase.
     login = models.CharField(db_column='Login', max_length=50, blank=True, null=True)  # Field name made lowercase.
@@ -495,12 +517,16 @@ class ServiceusagecontainerinfoT(models.Model):
 
 
 class ServiceusageT(models.Model):
-    id = models.CharField(db_column='ID', max_length=36, primary_key=True)  # Field name made lowercase.
+    #id = models.CharField(db_column='ID', max_length=36, primary_key=True)  # Field name made lowercase.
+    id = StringUUIDField(db_column='ID', primary_key=True)
     serviceprovider = models.CharField(db_column='ServiceProvider', max_length=36)  # Field name made lowercase.
     service = models.CharField(db_column='Service', max_length=36, blank=True, null=True)  # Field name made lowercase.
-    serviceconsumer = models.CharField(db_column='ServiceConsumer', max_length=36, blank=True, null=True)  # Field name made lowercase.
-    servconsgroup = models.CharField(db_column='ServConsGroup', max_length=36, blank=True, null=True)  # Field name made lowercase.
-    servconsproject = models.CharField(db_column='ServConsProject', max_length=36, blank=True, null=True)  # Field name made lowercase.
+    #serviceconsumer = models.CharField(db_column='ServiceConsumer', max_length=36, blank=True, null=True)  # Field name made lowercase.
+    serviceconsumer = models.ForeignKey(ServiceconsumerT, db_column='ServiceConsumer')
+    #servconsgroup = models.CharField(db_column='ServConsGroup', max_length=36, blank=True, null=True)  # Field name made lowercase.
+    servconsgroup = models.ForeignKey(ServiceconsumerT, db_column='ServConsGroup', related_name='serviceusage_servconsgroup_set')
+    #servconsproject = models.CharField(db_column='ServConsProject', max_length=36, blank=True, null=True)  # Field name made lowercase.
+    servconsproject = models.ForeignKey(ServiceconsumerT, db_column='ServConsProject', related_name='serviceusage_servconsproject_set')
     cardnumber = models.IntegerField(db_column='CardNumber', blank=True, null=True)  # Field name made lowercase.
     classdata = models.BinaryField(db_column='ClassData', blank=True, null=True)  # Field name made lowercase.
     usagebegin = models.DateTimeField(db_column='UsageBegin', blank=True, null=True)  # Field name made lowercase.
@@ -532,7 +558,8 @@ class ServiceusageT(models.Model):
 
 
 class ServiceT(models.Model):
-    id = models.CharField(db_column='ID', max_length=36, primary_key=True)  # Field name made lowercase.
+    #id = models.CharField(db_column='ID', max_length=36, primary_key=True)  # Field name made lowercase.
+    id = StringUUIDField(db_column='ID', primary_key=True)
     classdata = models.BinaryField(db_column='ClassData', blank=True, null=True)  # Field name made lowercase.
     name = models.CharField(db_column='Name', max_length=50, blank=True, null=True)  # Field name made lowercase.
     serviceprovider = models.CharField(db_column='ServiceProvider', max_length=36)  # Field name made lowercase.

--- a/src/build2myprint/models.py
+++ b/src/build2myprint/models.py
@@ -135,20 +135,20 @@ class BasystemlogT(models.Model):
 
 
 class BudgettransactionsT(models.Model):
-    transactiontime = models.DateTimeField(db_column='TransactionTime')  # Field name made lowercase.
+    transactiontime = models.DateTimeField(db_column='TransactionTime', primary_key=True)  # Field name made lowercase.
     transactiontype = models.IntegerField(db_column='TransactionType')  # Field name made lowercase.
     amount = models.FloatField(db_column='Amount', blank=True, null=True)  # Field name made lowercase.
     #entity = models.CharField(db_column='Entity', max_length=36)  # Field name made lowercase.
-    entity = models.ForeignKey('ServiceconsumerT', db_column='Entity')
+    entity = models.ForeignKey('ServiceconsumerT', db_column='Entity', primary_key=True)
     #service = models.CharField(db_column='Service', max_length=36, blank=True, null=True)  # Field name made lowercase.
     service = models.ForeignKey('ServiceT', db_column='Service')
-    #serviceusage = models.CharField(db_column='ServiceUsage', max_length=36, blank=True, null=True)  # Field name made lowercase.
-    service = models.ForeignKey('ServiceusageT', db_column='ServiceUsage')
+    serviceusage = models.CharField(db_column='ServiceUsage', max_length=36, blank=True, null=True)  # Field name made lowercase.
     transactiondata = models.CharField(db_column='TransactionData', max_length=100, blank=True, null=True)  # Field name made lowercase.
 
     class Meta:
         managed = False
         db_table = 'BudgetTransactions_T'
+        unique_together = ('entity', 'transactiontime')
 
 
 class Camipro(models.Model):
@@ -202,9 +202,11 @@ class ConsumergrouplinksT(models.Model):
 
 
 class ConsumeridentitiesT(models.Model):
-    id = models.CharField(db_column='ID', max_length=36, primary_key=True)  # Field name made lowercase.
+    # id = models.CharField(db_column='ID', max_length=36, primary_key=True)  # Field name made lowercase.
+    id = StringUUIDField(db_column='ID', primary_key=True)
     classdata = models.BinaryField(db_column='ClassData')  # Field name made lowercase.
-    consumerid = models.CharField(db_column='ConsumerID', max_length=36)  # Field name made lowercase.
+    # consumerid = models.CharField(db_column='ConsumerID', max_length=36)  # Field name made lowercase.
+    consumerid = StringUUIDField(db_column='ConsumerID', primary_key=True)
     identitycategory = models.IntegerField(db_column='IdentityCategory')  # Field name made lowercase.
     identitytype = models.CharField(db_column='IdentityType', max_length=50, blank=True, null=True)  # Field name made lowercase.
     value = models.CharField(db_column='Value', max_length=255, blank=True, null=True)  # Field name made lowercase.
@@ -300,12 +302,16 @@ class EventsT(models.Model):
 
 
 class GroupmembershipT(models.Model):
-    userid = models.CharField(db_column='UserID', max_length=36)  # Field name made lowercase.
-    groupid = models.CharField(db_column='GroupID', max_length=36, blank=True, null=True)  # Field name made lowercase.
+    # userid = models.CharField(db_column='UserID', max_length=36)  # Field name made lowercase.
+    # userid = StringUUIDField(db_column='UserID', primary_key=True)
+    userid = models.ForeignKey('ServiceconsumerT', db_column='UserID', primary_key=True)
+    # groupid = models.CharField(db_column='GroupID', max_length=36, blank=True, null=True)  # Field name made lowercase.
+    groupid = StringUUIDField(db_column='GroupID', blank=True, null=True)
 
     class Meta:
         managed = False
         db_table = 'GroupMembership_T'
+        unique_together = ('userid', 'groupid')
 
 
 class MomsystemtasksT(models.Model):


### PR DESCRIPTION
J'ai fait en sorte de remplacer certains attributs que Django avait interprété comme des CharFields par des ForeignKey.

Globalement, une fois cette pull request mergée vous pouvez faire
```
./start_shell.sh

>>> from build2myprint.models import ServiceconsumerT
>>> t = ServiceconsumerT.objects.get(login='gbrechbu')
>>> jobs = t.serviceusage_set.all()
```
`jobs` est une liste contenant tous les jobs effectué par moi-même en l'occurence, `jobs[0].amountpaid` contient le prix que m'a coûté le premier job de la liste.

Maintenant, on peut récupérer facilement des utilisateurs et leurs jobs. La chose qu'il nous manque c'est de pouvoir facilement trier les étudiants et trouver la faculté qui leur est lié et pour le coup je ne sais encore pas du tout où se trouvent ses infos.
Tout ce que je sais c'est si je cherche Nils (j'avais besoin d'un étudiant :D) dans la table ServiceConsumer_T, je trouve dans la colonne DefaultGroupID un ID qui m'amène à une ligne dans la même table nommée "Etudiant", mais je n'ai aucune information supplémentaire.

Dans la table BudgetTransaction_T il y a plusieurs infos qu'il faudrait étudier peut-être qu'on peut récupérer quelque-chose depuis là.
Je dirais que c'est la seule chose qui manque vraiment : y-a-t'il des entrées qui représentent les facultés/départements ? Si oui, comment sont-elles liées aux étudiants ?

PS : je vous laisse le temps de lire ce que j'ai fais ça peut vous intéresser et je mergerai ça dans master après.